### PR TITLE
ENH: Use alpha

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -1539,13 +1539,14 @@ class _BaseRaw(ProjMixin, ContainsMixin, UpdateChannelsMixin,
     def plot_psd(self, tmin=0.0, tmax=60.0, fmin=0, fmax=np.inf,
                  proj=False, n_fft=2048, picks=None, ax=None,
                  color='black', area_mode='std', area_alpha=0.33,
-                 n_overlap=0, dB=True, average=False, show=True,
-                 n_jobs=1, verbose=None):
+                 n_overlap=0, dB=True, average=True, show=True,
+                 n_jobs=1, line_alpha=None, verbose=None):
         return plot_raw_psd(self, tmin=tmin, tmax=tmax, fmin=fmin, fmax=fmax,
                             proj=proj, n_fft=n_fft, picks=picks, ax=ax,
                             color=color, area_mode=area_mode,
                             area_alpha=area_alpha, n_overlap=n_overlap,
-                            dB=dB, average=average, show=show, n_jobs=n_jobs)
+                            dB=dB, average=average, show=show, n_jobs=n_jobs,
+                            line_alpha=line_alpha)
 
     @copy_function_doc_to_method_doc(plot_raw_psd_topo)
     def plot_psd_topo(self, tmin=0., tmax=None, fmin=0, fmax=100, proj=False,

--- a/mne/viz/raw.py
+++ b/mne/viz/raw.py
@@ -518,7 +518,7 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
                  n_fft=2048, picks=None, ax=None, color='black',
                  area_mode='std', area_alpha=0.33,
                  n_overlap=0, dB=True, average=True, show=True, n_jobs=1,
-                 verbose=None):
+                 line_alpha=None, verbose=None):
     """Plot the power spectral density across channels.
 
     Parameters
@@ -564,6 +564,9 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
         Show figure if True.
     n_jobs : int
         Number of jobs to run in parallel.
+    line_alpha : float | None
+        Alpha for the PSD line. Can be None (default) to use 1.0 when
+        ``average=True`` and 0.1 when ``average=False``.
     verbose : bool, str, int, or None
         If not None, override default verbose level (see mne.verbose).
 
@@ -574,6 +577,9 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
     """
     fig, picks_list, titles_list, ax_list, make_label = _set_psd_plot_params(
         raw.info, proj, picks, ax, area_mode)
+    if line_alpha is None:
+        line_alpha = 1.0 if average else 0.1
+    line_alpha = float(line_alpha)
 
     for ii, (picks, title, ax) in enumerate(zip(picks_list, titles_list,
                                                 ax_list)):
@@ -605,12 +611,12 @@ def plot_raw_psd(raw, tmin=0., tmax=np.inf, fmin=0, fmax=np.inf, proj=False,
             else:  # area_mode is None
                 hyp_limits = None
 
-            ax.plot(freqs, psd_mean, color=color)
+            ax.plot(freqs, psd_mean, color=color, alpha=line_alpha)
             if hyp_limits is not None:
                 ax.fill_between(freqs, hyp_limits[0], y2=hyp_limits[1],
                                 color=color, alpha=area_alpha)
         else:
-            ax.plot(freqs, psds.T, color=color)
+            ax.plot(freqs, psds.T, color=color, alpha=line_alpha)
 
         if make_label:
             if ii == len(picks_list) - 1:

--- a/mne/viz/tests/test_raw.py
+++ b/mne/viz/tests/test_raw.py
@@ -157,7 +157,8 @@ def test_plot_raw_psd():
     raw.plot_psd(tmax=2.0)
     # specific mode
     picks = pick_types(raw.info, meg='mag', eeg=False)[:4]
-    raw.plot_psd(picks=picks, area_mode='range')
+    raw.plot_psd(picks=picks, area_mode='range', average=False)
+    plt.close('all')
     ax = plt.axes()
     # if ax is supplied:
     assert_raises(ValueError, raw.plot_psd, ax=ax)


### PR DESCRIPTION
I'm happy to change `tmax=np.inf` as a bugfix if you want, too. It's not good that `raw.plot_psd()` doesn't capture all properties of the recording by default.